### PR TITLE
Fix issue 307: undefined method cost for nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master [(unreleased)](https://github.com/whitesmith/rubycritic/compare/v4.5.2...master)
 
+* [BUGFIX] Handle missing comparison file in html template (by @lauratpa)
+
 # v4.5.2 / 2020-08-20 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.5.1...v4.5.2)
 
 * [BUGFIX] Handle simplecov v0.19 and install appraisal (by [@MZiserman][])

--- a/lib/rubycritic/generators/html/templates/code_index.html.erb
+++ b/lib/rubycritic/generators/html/templates/code_index.html.erb
@@ -25,7 +25,9 @@
                 <td class="center">
                   <% if Config.build_mode? %>
                     <% master_analysed_module = Config.base_branch_collection.find(analysed_module.pathname) %>
-                    <% if master_analysed_module.cost > analysed_module.cost %>
+                    <% if !master_analysed_module %>
+                      <span class="empty-span glyphicon"></span>
+                    <% elsif master_analysed_module.cost > analysed_module.cost %>
                       <span class="glyphicon glyphicon-arrow-up green-color"></span>
                     <% elsif master_analysed_module.cost < analysed_module.cost %>
                       <span class="glyphicon glyphicon-arrow-down red-color"></span>


### PR DESCRIPTION
This PR fixes #307. This bug occurs when a branch that is being compared
contains a file that is not present on the other branch.
In this template the files are being compared to one another, but not all
files have to have corresponding file on the second branch.

Check list:
- [ ] Add an entry to the [changelog](/CHANGELOG.md)
- [ ] [Squash all commits into a single one](/CONTRIBUTING.md)
- [ ] Describe your PR, link issues, etc.
